### PR TITLE
Bugfix - rolling doubles to go to jail

### DIFF
--- a/SUTDMonopoly.py
+++ b/SUTDMonopoly.py
@@ -633,6 +633,7 @@ def gameround(player_id):
             print("Free parking, take a break!")
         elif tiles[player_pos].get_type() == "goToJail":
             jail(player_id)
+            return
         else:
             print("Some error occurred.")
         

--- a/SUTDMonopoly.py
+++ b/SUTDMonopoly.py
@@ -633,11 +633,13 @@ def gameround(player_id):
             print("Free parking, take a break!")
         elif tiles[player_pos].get_type() == "goToJail":
             jail(player_id)
-            return
         else:
             print("Some error occurred.")
         
         update_board(player_id, dice1, dice2)
+        
+        if (player.get_status() == "Jail"):
+            return
         
     pass
 


### PR DESCRIPTION
Found that rolling doubles to get to the "go to jail" space allows the player to still roll to move one more time even though they are 'jailed'. Added a return after jail(player_id) to terminate gameround() after a player gets sent to jail.